### PR TITLE
유니티 ver2017.1.3f 다운그레이드시 발생한 오류 수정

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -3935,7 +3935,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -173}
+  m_AnchoredPosition: {x: 0, y: -165}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &573642010
@@ -3959,10 +3959,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 89abd5eec98699d42bbb0aabb5719f36, type: 3}
-    m_FontSize: 90
+    m_FontSize: 50
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 7
+    m_MinSize: 0
     m_MaxSize: 90
     m_Alignment: 1
     m_AlignByGeometry: 0
@@ -5047,8 +5047,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -685, y: 242}
-  m_SizeDelta: {x: 1920, y: 100}
+  m_AnchoredPosition: {x: -364, y: 126}
+  m_SizeDelta: {x: 1920, y: 95.3}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1009353409
 MonoBehaviour:
@@ -5088,10 +5088,10 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 89abd5eec98699d42bbb0aabb5719f36, type: 3}
-    m_FontSize: 73
+    m_FontSize: 55
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 7
+    m_MinSize: 0
     m_MaxSize: 90
     m_Alignment: 3
     m_AlignByGeometry: 0
@@ -6819,9 +6819,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1653332261
-  m_SortingLayer: 15
-  m_SortingOrder: 0
+  m_SortingLayerID: 234816309
+  m_SortingLayer: 18
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 006f308a424193c4d9f4f90026f81aca, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -8595,9 +8595,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 1150053011
-  m_SortingLayer: 16
-  m_SortingOrder: 0
+  m_SortingLayerID: 234816309
+  m_SortingLayer: 18
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 962a0230429f6ee4fa3a49dc8e55aef5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -10361,6 +10361,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e9ffbf813dc7f34188fac1cce7237e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Story: {fileID: 1145634328}
 --- !u!114 &1819456244
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10567,9 +10568,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 1150053011
-  m_SortingLayer: 16
-  m_SortingOrder: 0
+  m_SortingLayerID: 234816309
+  m_SortingLayer: 18
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: a0bbf473e0c23da46b58c3fd40bef834, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Scenes/Mini_1.unity
+++ b/Assets/Scenes/Mini_1.unity
@@ -2907,7 +2907,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 127987293}
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:

--- a/Assets/Scenes/Mini_2.unity
+++ b/Assets/Scenes/Mini_2.unity
@@ -138,7 +138,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 493812113}
-  m_RootOrder: 6
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -299,7 +299,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -1.82, y: 0}
+  m_AnchoredPosition: {x: -1.8200073, y: 0}
   m_SizeDelta: {x: 18.28, y: 20.12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &246566916
@@ -434,7 +434,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 493812113}
-  m_RootOrder: 9
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -766,6 +766,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 468887730}
+  - component: {fileID: 468887731}
   m_Layer: 5
   m_Name: pauseCanvas
   m_TagString: Untagged
@@ -788,7 +789,7 @@ RectTransform:
   - {fileID: 327226376}
   - {fileID: 547751959}
   - {fileID: 1270691349}
-  m_Father: {fileID: 493812113}
+  m_Father: {fileID: 1008785173}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -796,6 +797,48 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!212 &468887731
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 468887729}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -2073378669
+  m_SortingLayer: 17
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
 --- !u!1 &493812109
 GameObject:
   m_ObjectHideFlags: 0
@@ -868,7 +911,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 1150053011
+  m_SortingLayerID: -2073378669
   m_SortingOrder: 0
   m_TargetDisplay: 0
 --- !u!224 &493812113
@@ -881,12 +924,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 1077047378}
-  - {fileID: 468887730}
-  - {fileID: 981091476}
-  - {fileID: 1362137313}
-  - {fileID: 728337233}
-  - {fileID: 2061359080}
+  - {fileID: 1008785173}
   - {fileID: 7849117}
   - {fileID: 724679029}
   - {fileID: 1388723645}
@@ -1343,7 +1381,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 493812113}
-  m_RootOrder: 7
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1412,17 +1450,17 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 728337232}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1309646511}
-  m_Father: {fileID: 493812113}
-  m_RootOrder: 4
+  m_Father: {fileID: 1008785173}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 563, y: -107.099976}
+  m_AnchoredPosition: {x: -347.00006, y: 382.90005}
   m_SizeDelta: {x: 800, y: 146}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &728337234
@@ -1782,6 +1820,14 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4289845594263162, guid: 2df1acd062c4068479f21ec8b975ec4a, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4052624230013570, guid: 2df1acd062c4068479f21ec8b975ec4a, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 2df1acd062c4068479f21ec8b975ec4a, type: 2}
   m_IsPrefabParent: 0
@@ -1993,17 +2039,17 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 981091475}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 567027968}
-  m_Father: {fileID: 493812113}
-  m_RootOrder: 2
+  m_Father: {fileID: 1008785173}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -564, y: -72}
+  m_AnchoredPosition: {x: 345.99994, y: 418.00003}
   m_SizeDelta: {x: 160, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &981091478
@@ -2045,6 +2091,45 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 12
+--- !u!1 &1008785172
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1008785173}
+  m_Layer: 5
+  m_Name: ui
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1008785173
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1008785172}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1077047378}
+  - {fileID: 468887730}
+  - {fileID: 2061359080}
+  - {fileID: 728337233}
+  - {fileID: 981091476}
+  - {fileID: 1362137313}
+  m_Father: {fileID: 493812113}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1015452001
 GameObject:
   m_ObjectHideFlags: 0
@@ -2138,6 +2223,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c7090ef7034ef46ba3eca517b3c7ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameUI: {fileID: 1008785172}
   pauseBut: {fileID: 1077047373}
   speacialscore: 0
   normalscore: 0
@@ -2396,11 +2482,11 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1077047373}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 493812113}
+  m_Father: {fileID: 1008785173}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -3023,16 +3109,16 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1362137312}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 493812113}
-  m_RootOrder: 3
+  m_Father: {fileID: 1008785173}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -333, y: -82}
+  m_AnchoredPosition: {x: 576.99994, y: 408.00003}
   m_SizeDelta: {x: 160, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1362137314
@@ -3102,7 +3188,7 @@ RectTransform:
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 493812113}
-  m_RootOrder: 8
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4235,12 +4321,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 862235107}
-  m_Father: {fileID: 493812113}
-  m_RootOrder: 5
+  m_Father: {fileID: 1008785173}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 313, y: -200}
+  m_AnchoredPosition: {x: -597.00006, y: 290.00003}
   m_SizeDelta: {x: 300, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2061359081

--- a/Assets/Scenes/Mini_3.unity
+++ b/Assets/Scenes/Mini_3.unity
@@ -461,7 +461,7 @@ RectTransform:
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 890205634}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -613,7 +613,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 343891197}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -8600}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1510585570}
@@ -770,7 +770,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 890205634}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1536,7 +1536,7 @@ GameObject:
   - component: {fileID: 691691107}
   - component: {fileID: 691691106}
   m_Layer: 0
-  m_Name: BackToMain
+  m_Name: back_box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1563,7 +1563,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 691691104}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b43e2f748c1fd9644949e66ce9af1459, type: 3}
+  m_Script: {fileID: 11500000, guid: fb763aa8e4334c941af66fafdda6c3cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!61 &691691107
@@ -1620,8 +1620,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -2073378669
+  m_SortingLayer: 17
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 407e20f1479633643ac4336150618fdc, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1752,6 +1752,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 1684850579}
+  - {fileID: 1510585570}
   - {fileID: 984514944}
   - {fileID: 345334815}
   - {fileID: 1439123926}
@@ -1819,7 +1821,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: -2073378669
-  m_SortingOrder: 1
+  m_SortingOrder: 3
   m_TargetDisplay: 0
 --- !u!1 &902678256
 GameObject:
@@ -1971,7 +1973,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 890205634}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2048,8 +2050,6 @@ RectTransform:
   m_Children:
   - {fileID: 2043772280}
   - {fileID: 1141154519}
-  - {fileID: 1510585570}
-  - {fileID: 1684850579}
   m_Father: {fileID: 1154329295}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2175,7 +2175,7 @@ GameObject:
   - component: {fileID: 1040406813}
   - component: {fileID: 1040406812}
   m_Layer: 0
-  m_Name: TryAgain
+  m_Name: PlayAgain_box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2202,7 +2202,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1040406810}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b43e2f748c1fd9644949e66ce9af1459, type: 3}
+  m_Script: {fileID: 11500000, guid: fb763aa8e4334c941af66fafdda6c3cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!61 &1040406813
@@ -2259,8 +2259,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -2073378669
+  m_SortingLayer: 17
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 4b6660734382aa24b96a487f0add575e, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2663,8 +2663,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -2073378669
+  m_SortingLayer: 17
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 6bde7c875f30d254c8b8ad4224ca3654, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2814,8 +2814,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -2073378669
+  m_SortingLayer: 17
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: b7bbedb303b6c8f4a850df8d89d73074, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2987,7 +2987,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 890205634}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3056,15 +3056,15 @@ RectTransform:
   m_GameObject: {fileID: 1510585569}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000521, y: 1.0000521, z: 1.0000521}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1358262932}
   - {fileID: 1040406811}
   - {fileID: 691691105}
   - {fileID: 1309023534}
   - {fileID: 343891198}
-  m_Father: {fileID: 992948850}
-  m_RootOrder: 2
+  m_Father: {fileID: 890205634}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3098,10 +3098,10 @@ RectTransform:
   m_GameObject: {fileID: 1684850578}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.9998999, y: 0.9998999, z: 0.9998999}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 992948850}
-  m_RootOrder: 3
+  m_Father: {fileID: 890205634}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Assets/Scripts/Main/ChangeCameraPos.cs
+++ b/Assets/Scripts/Main/ChangeCameraPos.cs
@@ -6,6 +6,8 @@ using UnityEngine.UI;
 public class ChangeCameraPos : MonoBehaviour
 {
 
+    public GameObject Story;
+
     GameObject[] Arrow = new GameObject[2];
     GameObject Camera;
     GameObject DataManager;
@@ -55,6 +57,7 @@ public class ChangeCameraPos : MonoBehaviour
             for(int i=0;i<MainObj.Length;i++){
                 MainObj[i].transform.Translate(+21f, 0, 0);
             }
+            Story.transform.Translate(+21f, 0, 0);
         }
         else
         {
@@ -63,6 +66,7 @@ public class ChangeCameraPos : MonoBehaviour
             for(int i=0;i<MainObj.Length;i++){
                 MainObj[i].transform.Translate(-21f, 0, 0);
             }
+            Story.transform.Translate(-21f, 0, 0);
         }
 
         CatObj.GetComponent<Cat_interact>().CatVolSetting();

--- a/Assets/Scripts/Main/Main_Manager.cs
+++ b/Assets/Scripts/Main/Main_Manager.cs
@@ -17,6 +17,8 @@ public class Main_Manager : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+        Time.timeScale = 1;
+
         MenuObj = GameObject.Find("Menu");
         AudioManager = GameObject.Find("AudioManager");
 

--- a/Assets/Scripts/Mini_2/Minigame3_Mananger.cs
+++ b/Assets/Scripts/Mini_2/Minigame3_Mananger.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 
 public class Minigame3_Mananger : MonoBehaviour {
 
+    public GameObject gameUI;
     public GameObject pauseBut;
 
     GameObject AudioManager;
@@ -194,6 +195,7 @@ public class Minigame3_Mananger : MonoBehaviour {
     public void callGameover()
     {
         GameOver.SetActive(true);
+        gameUI.SetActive(false);
         calculFinalScore();
         GameOverScore.GetComponent<AppearScore>().setFinalScore();
         Game.SetActive(false);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -97,3 +97,6 @@ TagManager:
   - name: pause
     uniqueID: 2221588627
     locked: 0
+  - name: info
+    uniqueID: 234816309
+    locked: 0


### PR DESCRIPTION
----
__상점__

1. 금액 출력 위치 및 폰트 크기 조절
2. 구매 info가 다른 ui에 묻히지 않도록 조절 

__메인화면__

1. 일시정지 후 메인화면 돌아왔을 때 timeScale=0이던 상태 수정
2. 공간 확장 후 게임 로딩씬 위치 수정 (camera pos)

__미니게임1__

1. 미니게임1에서 고양이 요구사항 말풍선 꼬리 불투명게이지 묻히던 것 수정
2. 게임오버시 플레이 ui 끄도록 변경

__미니게임2__
1. 미니게임2에서 resume 후 pauseBut setActive 빠진 것 추가

__미니게임3__
1. pause ui가 제대로 뜨지 않는 문제 해결